### PR TITLE
Initializing abstract and base causal model classes.

### DIFF
--- a/src/models/base_causal_model.py
+++ b/src/models/base_causal_model.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import abc
+from typing import Union, Tuple
+from pandas import DataFrame
+from graphviz import Digraph
+
+from causalgraphicalmodels import CausalGraphicalModel, StructuralCausalModel
+
+SIZE_TYPE = Union[Tuple[int], int]
+
+
+class AbstractCausalModel(metaclass=abc.ABCMeta):
+    @classmethod
+    def __subclasshook__(cls, subclass) -> bool:
+        return (
+        hasattr(subclass, 'draw') and callable(subclass.draw) and
+        hasattr(subclass, 'sample') and callable(subclass.sample))
+
+    @abc.abstractmethod
+    def draw(self) -> Digraph:
+        """Load in the data set"""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def sample(self, size: SIZE_TYPE) -> DataFrame:
+        """Extract text from the data set"""
+        raise NotImplementedError
+
+
+class CGM_Model(AbstractCausalModel, StructuralCausalModel):
+    """
+    Now, one's causal graphical models can inherit directly from this class.
+    """
+    def draw(self) -> Digraph:
+        return self.cgm.draw()
+
+    def sample(self, size: SIZE_TYPE) -> DataFrame:
+        return super(StructuralCausalModel, self).sample(n_samples=size)

--- a/src/models/base_causal_model.py
+++ b/src/models/base_causal_model.py
@@ -30,7 +30,18 @@ class AbstractCausalModel(metaclass=abc.ABCMeta):
 class CGM_Model(AbstractCausalModel, StructuralCausalModel):
     """
     Now, one's causal graphical models can inherit directly from this class.
+
+    Parameters
+    ----------
+    assignment_dict : dict.
+        Keys should be strings representing variable names. Values should be
+        functions that generate the key-variable from the variables parents.
+        See https://github.com/ijmbarr/causalgraphicalmodels for more info.
     """
+    def __init__(self, assignment_dict):
+        super(StructuralCausalModel, self).__init__(assignment_dict)
+        return None
+
     def draw(self) -> Digraph:
         return self.cgm.draw()
 


### PR DESCRIPTION
@bouzaghrane and @hassanobeid1994 
Please take a look. This addresses part of issue #36.

This is an example of what I had in mind for our causal model classes. I figure they need to be able to draw the causal graph for us to look at, and they need to provide samples from the underlying distribution specified by the model.

Let me know if any of this looks off. The idea is that when defining one's causal models in standalone python files, each causal model would inherit from `base_causal_models.CGM_Model`.