### PR TITLE
Add makefile targets for TB's part of project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,144 +1,36 @@
-.PHONY: clean data lint requirements sync_data_to_s3 sync_data_from_s3
+## plots       : Create the various plots for the handbook chapter.
+.PHONY : plots
+plots :
+	python -m src.workflow.testing_images_marginal
+	python -m src.workflow.testing_images_conditional
+	python -m src.workflow.testing_images_latent
 
-#################################################################################
-# GLOBALS                                                                       #
-#################################################################################
+## graphs      : Create the various causal graphs for the handbook chapter.
+.PHONY : graphs
+graphs :
+	python -m src.workflow.store_rum_graph
+	python -m src.workflow.store_iclv_graph
+	python -m src.workflow.store_drive_alone_utility_graph
+	python -m src.workflow.store_deconfounder_graph
+	python -m src.workflow.store_discovery_graph
 
-PROJECT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-BUCKET = [OPTIONAL] your-bucket-for-syncing-data (do not include 's3://')
-PROFILE = default
-PROJECT_NAME = ctr_b_causal_2020
-PYTHON_INTERPRETER = python3
+## imagesdir   : Copy the needed images into a common location for article compilation.
+.PHONY : imagedir
+imagedir : plots graphs
+	cp reports/figures/latent-drivers-vs-num-autos.pdf article/images/latent-drivers-vs-num-autos.pdf
+	cp reports/figures/rum-causal-graph.pdf article/images/rum-causal-graph.pdf
+	cp reports/figures/iclv-causal-graph.pdf article/images/iclv-causal-graph.pdf
+	cp reports/figures/drive-alone-utility-graph.pdf article/images/drive-alone-utility-graph.pdf
+	cp reports/figures/mit--num_drivers_vs_num_autos.png article/images/mit--num_drivers_vs_num_autos.png
+	cp reports/figures/cit--time_vs_cost_given_distance.png article/images/cit--time_vs_cost_given_distance.png
+	cp reports/figures/deconfounder-causal-graph.pdf article/images/deconfounder-causal-graph.pdf
+	cp reports/figures/latent-drivers-vs-num-autos.pdf article/images/latent-drivers-vs-num-autos.pdf
 
-ifeq (,$(shell which conda))
-HAS_CONDA=False
-else
-HAS_CONDA=True
-endif
+## article     : Compile the handbook chapter
+.PHONY : article
+article : imagedir
+	python article/compile_article.py
 
-#################################################################################
-# COMMANDS                                                                      #
-#################################################################################
-
-## Install Python Dependencies
-requirements: test_environment
-	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
-	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt
-
-## Make Dataset
-data: requirements
-	$(PYTHON_INTERPRETER) src/data/make_dataset.py data/raw data/processed
-
-## Delete all compiled Python files
-clean:
-	find . -type f -name "*.py[co]" -delete
-	find . -type d -name "__pycache__" -delete
-
-## Lint using flake8
-lint:
-	flake8 src
-
-## Upload Data to S3
-sync_data_to_s3:
-ifeq (default,$(PROFILE))
-	aws s3 sync data/ s3://$(BUCKET)/data/
-else
-	aws s3 sync data/ s3://$(BUCKET)/data/ --profile $(PROFILE)
-endif
-
-## Download Data from S3
-sync_data_from_s3:
-ifeq (default,$(PROFILE))
-	aws s3 sync s3://$(BUCKET)/data/ data/
-else
-	aws s3 sync s3://$(BUCKET)/data/ data/ --profile $(PROFILE)
-endif
-
-## Set up python interpreter environment
-create_environment:
-ifeq (True,$(HAS_CONDA))
-		@echo ">>> Detected conda, creating conda environment."
-ifeq (3,$(findstring 3,$(PYTHON_INTERPRETER)))
-	conda create --name $(PROJECT_NAME) python=3
-else
-	conda create --name $(PROJECT_NAME) python=2.7
-endif
-		@echo ">>> New conda env created. Activate with:\nsource activate $(PROJECT_NAME)"
-else
-	$(PYTHON_INTERPRETER) -m pip install -q virtualenv virtualenvwrapper
-	@echo ">>> Installing virtualenvwrapper if not already installed.\nMake sure the following lines are in shell startup file\n\
-	export WORKON_HOME=$$HOME/.virtualenvs\nexport PROJECT_HOME=$$HOME/Devel\nsource /usr/local/bin/virtualenvwrapper.sh\n"
-	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"
-	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
-endif
-
-## Test python environment is setup correctly
-test_environment:
-	$(PYTHON_INTERPRETER) test_environment.py
-
-#################################################################################
-# PROJECT RULES                                                                 #
-#################################################################################
-
-
-
-#################################################################################
-# Self Documenting Commands                                                     #
-#################################################################################
-
-.DEFAULT_GOAL := help
-
-# Inspired by <http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html>
-# sed script explained:
-# /^##/:
-# 	* save line in hold space
-# 	* purge line
-# 	* Loop:
-# 		* append newline + line to hold space
-# 		* go to next line
-# 		* if line starts with doc comment, strip comment character off and loop
-# 	* remove target prerequisites
-# 	* append hold space (+ newline) to line
-# 	* replace newline plus comments by `---`
-# 	* print line
-# Separate expressions are necessary because labels cannot be delimited by
-# semicolon; see <http://stackoverflow.com/a/11799865/1968>
-.PHONY: help
-help:
-	@echo "$$(tput bold)Available rules:$$(tput sgr0)"
-	@echo
-	@sed -n -e "/^## / { \
-		h; \
-		s/.*//; \
-		:doc" \
-		-e "H; \
-		n; \
-		s/^## //; \
-		t doc" \
-		-e "s/:.*//; \
-		G; \
-		s/\\n## /---/; \
-		s/\\n/ /g; \
-		p; \
-	}" ${MAKEFILE_LIST} \
-	| LC_ALL='C' sort --ignore-case \
-	| awk -F '---' \
-		-v ncol=$$(tput cols) \
-		-v indent=19 \
-		-v col_on="$$(tput setaf 6)" \
-		-v col_off="$$(tput sgr0)" \
-	'{ \
-		printf "%s%*s%s ", col_on, -indent, $$1, col_off; \
-		n = split($$2, words, " "); \
-		line_length = ncol - indent; \
-		for (i = 1; i <= n; i++) { \
-			line_length -= length(words[i]) + 1; \
-			if (line_length <= 0) { \
-				line_length = ncol - indent - length(words[i]) - 1; \
-				printf "\n%*s ", -indent, " "; \
-			} \
-			printf "%s ", words[i]; \
-		} \
-		printf "\n"; \
-	}' \
-	| more $(shell test $(shell uname) = Darwin && echo '--no-init --raw-control-chars')
+.PHONY : help
+help : Makefile
+	@sed -n 's/^##//p' $<

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ imagedir : plots graphs
 	cp reports/figures/cit--time_vs_cost_given_distance.png article/images/cit--time_vs_cost_given_distance.png
 	cp reports/figures/deconfounder-causal-graph.pdf article/images/deconfounder-causal-graph.pdf
 	cp reports/figures/latent-drivers-vs-num-autos.pdf article/images/latent-drivers-vs-num-autos.pdf
+	cp reports/figures/discovery-example-graph.pdf article/images/discovery-example-graph.pdf
 
 ## article     : Compile the handbook chapter
 .PHONY : article

--- a/src/graphs/discovery.py
+++ b/src/graphs/discovery.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""
+Causal graph resulting from the PC algorithm (Glymour et al., 2001) and the
+data from Brathwaite and Walker (2018).
+
+References
+----------
+Brathwaite, Timothy, and Joan L. Walker. "Asymmetric, closed-form,
+finite-parameter models of multinomial choice." Journal of choice modelling 29
+(2018): 78-112.
+
+Clark Glymour, Richard Scheines, and Peter Spirtes. Causation, prediction, and
+search. MIT Press, 2001.
+"""
+import graphviz
+
+TIME_COLUMN = "Travel Time"
+COST_COLUMN = "Travel Cost"
+DISTANCE_COLUMN = "Travel Distance"
+LICENSE_COLUMN = "Number of Licensed Drivers"
+NUM_AUTOS_COLUMN = "Number of Automobiles"
+
+DISCOVERY_GRAPH = graphviz.Digraph("DISCOVERY")
+
+# Add all nodes to the graph
+DISCOVERY_GRAPH.node("T", TIME_COLUMN)
+DISCOVERY_GRAPH.node("C", COST_COLUMN)
+DISCOVERY_GRAPH.node("D", DISTANCE_COLUMN)
+DISCOVERY_GRAPH.node("L", LICENSE_COLUMN)
+DISCOVERY_GRAPH.node("A", NUM_AUTOS_COLUMN)
+
+# Add edges to the graph
+DISCOVERY_GRAPH.edge("L", "A")
+DISCOVERY_GRAPH.edge("D", "A")
+DISCOVERY_GRAPH.edge("D", "T")
+DISCOVERY_GRAPH.edge("D", "C")
+DISCOVERY_GRAPH.edge("C", "T", dir="none")
+
+# Display the graph
+# utils.create_graph_image(
+#     step_9_graph, output_name=PLOT_TITLE, output_type="pdf"
+# )
+
+DISCOVERY_GRAPH.graph_attr.update(size="10,6")
+DISCOVERY_GRAPH.node_attr.update(shape="box")
+DISCOVERY_GRAPH

--- a/src/workflow/store_discovery_graph.py
+++ b/src/workflow/store_discovery_graph.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+Stores the causal discovery example graph.
+
+To execute this module by itself, navigate at the command line to the project's
+root directory and type: `python -m src.workflow.store_discovery_graph`.
+"""
+import click
+
+from src import utils
+from src.graphs.discovery import DISCOVERY_GRAPH
+
+
+@click.command()
+@click.option(
+    "--output_name",
+    default="discovery-example-graph",
+    type=str,
+    help="Filename used to store the graph. Excludes extension.",
+    show_default=True,
+)
+def main(output_name):
+    # Write the image of the ICLV graph to file
+    utils.create_graph_image(
+        graph=DISCOVERY_GRAPH, output_name=output_name, output_type="pdf"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What
Addresses #131 and partially addresses #125 

This PR edits the makefile such that it contains part of this project's workflow. It performs the independence testing and creates the causal graphs for display, for @timothyb0912 's section of the project. Similar PR's for @bouzaghrane and @hassan-obeid are to come.

Additionally, this PR adds the causal discovery example graph as its own file, and it adds a script to render that graph and save the rendering as a .pdf file.