### PR TITLE
Removing py37

### DIFF
--- a/.github/workflows/project_workflow.yml
+++ b/.github/workflows/project_workflow.yml
@@ -22,7 +22,7 @@ jobs:
     # Set the python versions to use
     strategy:
       matrix:
-        python: [3.7, 3.8]
+        python: [3.8]
 
     steps:
       # Step 1: Check out a copy of your repository on the ubuntu-latest machine


### PR DESCRIPTION
# What
Self-explanatory. Removing python 3.7 from github actions. Likely issue is pytorch 3.7 build failing.
<img width="1125" alt="Screen Shot 2020-12-13 at 3 36 32 PM" src="https://user-images.githubusercontent.com/5533699/102027443-00383780-3d59-11eb-811c-98f7af511c76.png">

Should revisit this issue in the future and support (hopefully) py36 - py38.
