### PR TITLE
Adjusting causal graphs sizes in sections 2 and 3

### DIFF
--- a/article/sections/_2_graph_importance.tex
+++ b/article/sections/_2_graph_importance.tex
@@ -107,7 +107,7 @@ Each of these graphs is based on the utility function of each mode in the multin
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.2\textwidth]{Independent_graph.png}
+   \includegraphics[width=0.75\textwidth]{Independent_graph.png}
    \caption{Causal Graph with Independent Covariates}
    \label{fig:IND_GRAPH}
 \end{figure}

--- a/article/sections/_3_graph_overview.tex
+++ b/article/sections/_3_graph_overview.tex
@@ -22,7 +22,7 @@ In such situations, it is sufficient to control for X to obtain an unbiased esti
 
 \begin{figure}[h!]
    \centering
-   \includegraphics[height=0.5\textwidth]{simple-graph.pdf}
+   \includegraphics[height=0.25\textwidth]{simple-graph.pdf}
    \caption{Simple DAG of the causal relationships between X, Y and Z}
    \label{fig:simple-graph}
 \end{figure}
@@ -41,7 +41,7 @@ Figure \ref{fig:simple-graph-confounded} illustrates this assumption in DAG form
 
 \begin{figure}[h!]
    \centering
-   \includegraphics[height=0.5\textwidth]{simple-graph-confounded.pdf}
+   \includegraphics[height=0.25\textwidth]{simple-graph-confounded.pdf}
    \caption{Simple DAG of the causal relationships between X, Y, Z and confounder U}
    \label{fig:simple-graph-confounded}
 \end{figure}
@@ -99,7 +99,7 @@ Without more detailed causal knowledge, our inferences may be inconsistent and a
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.5\textwidth]{iclv-causal-graph}
+   \includegraphics[width=0.35\textwidth]{iclv-causal-graph}
    \caption{Archetypical ICLV causal diagram}
    \label{fig:example-graph-iclv}
 \end{figure}


### PR DESCRIPTION
# What
Previously all graphs in section 3 were `0.5\textwidth`.
Now, they've been reduced in Section 3 (as appropriate by graph) to a smaller size that matches the other sections.

Additionally the independent graph in section 2 was enlarged because it was tiny and hard to read.
This was especially blatant next to the much larger dependent graph for the drive alone utility.

cc @hassan-obeid and @bouzaghrane for visibility.