### PR TITLE
Programmatically store causal graphs for Sec 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ graphs :
 	python workflow/store_drive_alone_utility_graph.py
 	python workflow/store_deconfounder_graph.py
 	python workflow/store_discovery_graph.py
+	python workflow/store_sob_graphs.py
 
 ## imagesdir   : Copy the needed images into a common location for article compilation.
 .PHONY : imagedir
@@ -34,6 +35,15 @@ imagedir : plots graphs
 	cp reports/figures/deconfounder-causal-graph.pdf article/images/deconfounder-causal-graph.pdf
 	cp reports/figures/latent-drivers-vs-num-autos.pdf article/images/latent-drivers-vs-num-autos.pdf
 	cp reports/figures/discovery-example-graph.pdf article/images/discovery-example-graph.pdf
+	cp reports/figures/Independent_graph.pdf article/images/Independent_graph.pdf
+	cp reports/figures/DA_interacting_graph.pdf article/images/DA_interacting_graph.pdf
+	cp reports/figures/SR2_interacting_graph.pdf article/images/SR2_interacting_graph.pdf
+	cp reports/figures/SR3_interacting_graph.pdf article/images/SR3_interacting_graph.pdf
+	cp reports/figures/WTW_interacting_graph.pdf article/images/WTW_interacting_graph.pdf
+	cp reports/figures/DTW_interacting_graph.pdf article/images/DTW_interacting_graph.pdf
+	cp reports/figures/WTD_interacting_graph.pdf article/images/WTD_interacting_graph.pdf
+	cp reports/figures/BIKE_interacting_graph.pdf article/images/BIKE_interacting_graph.pdf
+	cp reports/figures/WALK_interacting_graph.pdf article/images/WALK_interacting_graph.pdf
 
 ## notebooks     : Execute all jupyter notebooks for the project.
 .PHONY : notebooks

--- a/article/sections/_2_graph_importance.tex
+++ b/article/sections/_2_graph_importance.tex
@@ -107,63 +107,63 @@ Each of these graphs is based on the utility function of each mode in the multin
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.75\textwidth]{Independent_graph.png}
+   \includegraphics[width=0.75\textwidth]{Independent_graph}
    \caption{Causal Graph with Independent Covariates}
    \label{fig:IND_GRAPH}
 \end{figure}
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.75\textwidth]{DA_interacting_graph.png}
+   \includegraphics[width=0.75\textwidth]{DA_interacting_graph}
    \caption{Causal Graph for the Drive Alone Utility Function}
    \label{fig:DA_causal_2}
 \end{figure}
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.75\textwidth]{SR2_interacting_graph.png}
+   \includegraphics[width=0.75\textwidth]{SR2_interacting_graph}
    \caption{Causal Graph for the Shared Ride 2 Utility Function}
    \label{fig:SR2_causal_2}
 \end{figure}
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.75\textwidth]{SR3_interacting_graph.png}
+   \includegraphics[width=0.75\textwidth]{SR3_interacting_graph}
    \caption{Causal Graph for the Shared Ride 3+ Utility Function}
    \label{fig:SR3_causal_2}
 \end{figure}
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.2\textwidth]{WTW_interacting_graph.png}
+   \includegraphics[width=0.2\textwidth]{WTW_interacting_graph}
    \caption{Causal Graph for the Walk-Transit-Walk Utility Function}
    \label{fig:WTW_causal_2}
 \end{figure}
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.2\textwidth]{WTD_interacting_graph.png}
+   \includegraphics[width=0.2\textwidth]{WTD_interacting_graph}
    \caption{Causal Graph for the Walk-Transit-Drive Utility Function}
    \label{fig:WTD_causal_2}
 \end{figure}
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.2\textwidth]{DTW_interacting_graph.png}
+   \includegraphics[width=0.2\textwidth]{DTW_interacting_graph}
    \caption{Causal Graph for the Drive-Transit-Walk Utility Function}
    \label{fig:DTW_causal_2}
 \end{figure}
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.2\textwidth]{WALK_interacting_graph.png}
+   \includegraphics[width=0.2\textwidth]{WALK_interacting_graph}
    \caption{Causal Graph for the Shared Ride 3+ Utility Function}
    \label{fig:WALK_causal_2}
 \end{figure}
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.2\textwidth]{BIKE_interacting_graph.png}
+   \includegraphics[width=0.2\textwidth]{BIKE_interacting_graph}
    \caption{Causal Graph for the Bike Utility Function}
    \label{fig:BIKE_causal_2}
 \end{figure}

--- a/workflow/store_sob_graphs.py
+++ b/workflow/store_sob_graphs.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+Stores all causal graphs for the utility equations in Section 2 of the article.
+"""
+import causal2020.observables.graphs as graphs
+import click
+from causal2020 import utils
+
+
+def main_func(supplier=graphs, writer=utils) -> bool:
+    sob_graphs = {
+        "Independent_graph": supplier.IND_UTILITY,
+        "DA_interacting_graph": supplier.DA_UTILITY,
+        "SR2_interacting_graph": supplier.SHARED_2_UTILITY,
+        "SR3_interacting_graph": supplier.SHARED_3P_UTILITY,
+        "WTW_interacting_graph": supplier.WTW_UTILITY,
+        "DTW_interacting_graph": supplier.DTW_UTILITY,
+        "WTD_interacting_graph": supplier.WTD_UTILITY,
+        "BIKE_interacting_graph": supplier.BIKE_UTILITY,
+        "WALK_interacting_graph": supplier.WALK_UTILITY,
+    }
+
+    # Write the image of each graph to file
+    for output_name in sob_graphs:
+        writer.create_graph_image(
+            graph=sob_graphs[output_name],
+            output_name=output_name,
+            output_type="pdf",
+        )
+
+    return True
+
+
+@click.command()
+def main() -> bool:
+    main_func()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What
This PR fixes #194. It programmatically stores all causal graphs for Section 2 and it uses the pdf representations of those graphs as images in the chapter.

cc @bouzaghrane for visibility.