### PR TITLE
sob histogram 0.5 -> 0.95\textwidth

### DIFF
--- a/article/sections/_2_graph_importance.tex
+++ b/article/sections/_2_graph_importance.tex
@@ -212,7 +212,7 @@ Of course, the importance of a correct causal graph does not and should not take
 
 \begin{figure}[h!]
    \centering
-   \includegraphics[width=0.5\textwidth]{histogram_selection_on_obs}
+   \includegraphics[width=0.95\textwidth]{histogram_selection_on_obs}
    \caption{Histograms of the probability of choosing Car Centric Modes under Different Data Generating processes.}
    \label{fig:histogram_probability}
 \end{figure}


### PR DESCRIPTION
# What
Makes the comparison histogram of causal effect estimates in Section 2 `0.95\textwidth` instead of `0.5\textwidth`.
It was hard to read the text on the plot at 0.5.

cc @bouzaghrane for visibility.