### PR TITLE
Removing old, unnecessarily nested section headers

### DIFF
--- a/article/sections/_5_graph_testing.tex
+++ b/article/sections/_5_graph_testing.tex
@@ -1,11 +1,9 @@
 \section{Testing of Causal Graphs}
 \label{sec:graph-testing}
 
-\subsection{Description}
-\label{sec:testing-description}
-
-\subsubsection{Testing observable assumptions}
+\subsection{Testing observable assumptions}
 \label{sec:observable-tests}
+
 In the last section, we reviewed a process for creating an initial causal graph using expert opinion.
 Critically, after drafting a causal graph, we should test it against our available data.
 Doing so will add robustness and credibility to our final conclusions.
@@ -140,7 +138,7 @@ And finally, if one takes a toll lane to get across the bridge faster, then one 
 Overall, intuitive explanations exist for conditional dependence between travel time and travel cost.
 These explanations suggest particular relationships to analyze and particular variables, such as bay bridge crossings, to include in one's mode choice (i.e. outcome) model.
 
-\subsubsection{Testing assumptions involving latent variables}
+\subsection{Testing assumptions involving latent variables}
 \label{sec:latent-tests}
 % Describe latent variable testing
 Now that we have described testing with observable variables, we can more easily describe conditional independence tests that involve unobserved (i.e., latent) variables.


### PR DESCRIPTION
# What
This PR removes the triple-level section headings in Section 5.
Now, headings are restricted to one level of nesting: 5, 5.1, 5.2, etc.

cc @hassan-obeid and @bouzaghrane for visibility.