### PR TITLE
Fix typos

### DIFF
--- a/article/main.tex
+++ b/article/main.tex
@@ -42,7 +42,7 @@
 \usepackage{blindtext}
 
 % Declare article info
-\title{Causal Graphs in Choice Modeling: The What, Why, and How}
+\title{Causal Graphs in Choice Modelling: The What, Why, and How}
 %\author{Timothy Brathwaite, Mohamed Amine Bouzaghrane, Hassan Obeid}
 \author{}
 

--- a/article/sections/_1_intro_generic.tex
+++ b/article/sections/_1_intro_generic.tex
@@ -3,7 +3,7 @@
 
 In transportation, we often build models for policy evaluation.
 Specifically, we often use behavioral models to evaluate the impact of external interventions on travel outcomes.
-These evaluations are excplicitly causal: we are interested in how the
+These evaluations are explicitly causal: we are interested in how the
 system reacts to \textit{interventions}.
 Yet, when these models are
 developed, causality is often not considered. Furthermore, when
@@ -18,7 +18,7 @@ the causal inference literature in travel demand modelling and choice modelling 
 While the field of transportation demand modelling could benefit greatly from
 incorporating causal inference techniques, there are barriers that have slowed this integration.
 These barriers stem from the difference between the types of problems transportation demand modellers deal with and those that are typically studied in the causal inference literature.
-Perhaps the fundemental difference is that demand modellers are typically trying to forecast the impacts of policies that haven't been implemented or seen before.
+Perhaps the fundamental difference is that demand modellers are typically trying to forecast the impacts of policies that haven't been implemented or seen before.
 Forecasting the effects of unseen interventions requires additional work and a change to the typical causal modelling workflow.
 In particular, we must translate a given policy (treatment) into a set of characteristics and variables that exist in the data and system at hand.
 (For a more thorough discussion of this and other barriers, please refer to \citet{brathwaite_2018_causal}.)

--- a/article/sections/_1_intro_generic.tex
+++ b/article/sections/_1_intro_generic.tex
@@ -45,4 +45,4 @@ the confounded variables but are correlated with it, which biases the estimated
 causal effects of those variables if nothing is done to account for the
 confounding.
 In Section \ref{sec:latent-confounding}, we focus on a recent technique to deal with latent confounding suggested by \citet{wang_2019_blessings} to address unobserved confounding when collecting additional data is not feasible.
-Finally, in Section \ref{sec:discussion}, we briefly discuss the many subsequent and important steps that are necessary for making and benefitting from one's causal inferences.
+Finally, in Section \ref{sec:discussion}, we briefly discuss the many subsequent and important steps that are necessary for making and benefiting from one's causal inferences.

--- a/article/sections/_5_graph_testing.tex
+++ b/article/sections/_5_graph_testing.tex
@@ -30,7 +30,7 @@ Mean independence simply provides justification for placing greater belief in th
 
 This approach of indirectly assessing distributional independence by testing mean independence is not new.
 The following papers have all proposed and implemented such an idea: \citet{burkart_2017_predictive, chalupka_2018_fast, inacio_2019_conditional}.
-For conditional independences, the crux of the approach is to predict $Y$ based on $X$ and $Z$.
+For conditional independencies, the crux of the approach is to predict $Y$ based on $X$ and $Z$.
 Then, compare against a prediction of $Y$ based on a resampled value of $X$ and the original $Z$.
 If $Y$ is mean-independent of $X$ given $Z$, i.e. $E \left[ Y \mid X, Z \right] = E\left[ Y \mid Z \right]$, then the predictive power of a model with resampled $X$ should resemble the predictive power of a model with the original $X$.
 After all, in both cases, the conditional expectation of $Y$ is independent of our $X$ values (real or resampled).

--- a/article/sections/_6_graph_discovery.tex
+++ b/article/sections/_6_graph_discovery.tex
@@ -96,7 +96,7 @@ Crucially, we rely heavily on review papers such as \citet{glymour_2019_review} 
 
 % Types of causal discovery algorithms
 Overall, there are three classes of causal discovery algorithms.
-One class attempts to directly infer the marginal and conditional independences in one's causal system.
+One class attempts to directly infer the marginal and conditional independencies in one's causal system.
 That is, this class of algorithms identifies a so-called Markov Equivalence Class (MEC) of graphs.
 Considering the discussion of independence testing in Section \ref{sec:graph-testing}, this class of algorithms is perhaps best understood as repeated and systematic independence tests.
 These causal discovery algorithms are constraint-based algorithms, because the observed independencies represent constraints that define the space of plausible causal graphs for the dataset.

--- a/article/sections/_8_discussion.tex
+++ b/article/sections/_8_discussion.tex
@@ -43,7 +43,7 @@ In both cases, however, we pay great attention to the design of our experiments.
 When experimenting to make decisions, such as whether to launch a given treatment or not, we pay extra attention to the size of our experiment.
 Specifically, we want our experiment's sample size to be large enough such that after we update our beliefs using the experimental data, that we have at least our minimum desired probability of making the correct decision.
 The decision can be to declare the effect of a treatment statistically different from zero, but more frequently, the decision will be more fundamental such as ``implement treatment A.''
-For thorough explanations of how to conceptualize and design experiments in a bayesian, model-based setting, see \citet{chaloner_1995_bayesian} and \citet{wang_2002_simulation}.
+For thorough explanations of how to conceptualize and design experiments in a Bayesian, model-based setting, see \citet{chaloner_1995_bayesian} and \citet{wang_2002_simulation}.
 For examples and guidance on how to use one's causal graph structure to guide the general design of one's experiment, beyond sample size, see \citet{madrigal_2007_cluster}.
 There, the structure of one's causal graph is used to inform general design decisions such as the clustered allocation of individuals to treatment, and the experimental design is itself analyzed graphically.
 Additionally, note the relations to reinforcement learning where an agent has to perform experiments in order to discover the action/intervention that will maximize her expected, counterfactual reward.
@@ -81,6 +81,6 @@ In doing so, we should consult articles such as \citet{pearl_2017_detecting} and
 This should help us avoid drawing incorrect conclusions or misinterpreting our analyses.
 
 Thirdly, we will need to answer logistical questions about the levels and the frequency of treatment.
-With regard to choosing the levels of (possibly continuous and multiple) treatments, recent work on causal bayesian optimization represents the state of the art in this area \citep{aglietti_2020_causal}.
+With regard to choosing the levels of (possibly continuous and multiple) treatments, recent work on causal Bayesian optimization represents the state of the art in this area \citep{aglietti_2020_causal}.
 Moreover, the entire field of reinforcement learning focuses on running experiments and learning from past observations to determine the treatment arms/levels that will maximize one's reward (however we define it).
 Accordingly, we stand to gain much by consulting the work on and principles from causal reinforcement learning (c.f. \citet{bareinboim_2015_bandits}) when choosing our optimal treatment plan.


### PR DESCRIPTION
# What
This PR fixes various typos throughout the chapter:
- modeling -> modelling
- excplicitly -> explicitly
- fundemental -> fundamental
- independences -> independencies
- bayesian -> Bayesian
- benefitting -> benefiting

cc @hassan-obeid and @bouzaghrane for visibility.