### PR TITLE
Simplify final paragraph of intro

### DIFF
--- a/article/sections/_1_intro_generic.tex
+++ b/article/sections/_1_intro_generic.tex
@@ -38,11 +38,10 @@ to use a causal graph to estimate the causal relationships of interest.
 We will demonstrate the use of this framework through simulations, where we
 clearly show the benefits and implications of this approach as opposed to
 traditional approaches.
+
 The last part of this chapter deals with the more complicated issue of latent
-confounding, where one variable confounds two or more variables in the causal
-graph. This type of confounding creates variations in the outcome variable that are not caused by
-the confounded variables but are correlated with it, which biases the estimated
-causal effects of those variables if nothing is done to account for the
-confounding.
-In Section \ref{sec:latent-confounding}, we focus on a recent technique to deal with latent confounding suggested by \citet{wang_2019_blessings} to address unobserved confounding when collecting additional data is not feasible.
+confounding, where an unobserved variable confounds two or more variables in the causal graph.
+Confounding creates variations in the outcome variable that correlate with but are not caused by the treatment variables.
+These spurious correlations bias the estimated causal effects if nothing is done to account for them.
+In Section \ref{sec:latent-confounding}, we focus on a recent technique by \citet{wang_2019_blessings} for addressing unobserved confounding when collecting additional data is not feasible.
 Finally, in Section \ref{sec:discussion}, we briefly discuss the many subsequent and important steps that are necessary for making and benefiting from one's causal inferences.


### PR DESCRIPTION
# What
This PR splits a sentence that was formerly expressing two thoughts into two sentences (see the new lines 45 and 46).
It also removes extraneous words from the second to last sentence of the paragraph.

cc @hassan-obeid and @bouzaghrane for visibility.