### PR TITLE
Setup calver + towncrier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,8 @@
+=========
+Changelog
+=========
+
+The format is based on [Keep-a-Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Calendar Versioning](https://calver.org/).
+
+.. towncrier release notes start

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,5 @@
+This repository was contributed to by:
+
+  * Timothy Brathwaite (@timothyb0912)
+  * Mohamed Amine Bouzaghrane (@bouzaghrane)
+  * Hassan Obeid (@hassan-obeid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,65 @@ exclude = '''
   | tests/data
 )/
 '''
+
+[tool.bumpver]
+current_version = "2021.1000.5"
+version_pattern = "YYYY.BUILD.UU"
+commit_message = "bump version {old_version} -> {new_version}"
+commit = true
+tag = false
+push = false
+
+[tool.bumpver.file_patterns]
+"src/causal2020/__init__.py" = [
+    '__version__ = "{version}"',
+]
+
+
+[tool.towncrier]
+package = "causal2020"
+package_dir = "src"
+filename = "CHANGELOG.rst"
+title_format = "{name} {version} ({project_date})"
+wrap = true  # Wrap text to 79 characters
+all_bullets = true  # make all fragments bullet points
+
+  [[tool.towncrier.type]]
+  directory = "added"
+  name = "Added new features"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "changed"
+  name = "Changed existing functionality"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "deprecated"
+  name = "Marked for removal"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "removed"
+  name = "Removed from package"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "fixed"
+  name = "Bug fixes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "security"
+  name = "Patched vulnerabilities"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "doc"
+  name = "Improved Documentation"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "trivial"
+  name = "Trivial/Internal Changes"
+  showcontent = true

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 attrs
+bumpver
 causalgraphicalmodels
 checkrs
 click
@@ -22,4 +23,5 @@ statsmodels
 # tensorflow<1.15.2
 # tensorflow-probability<0.9
 torch<1.7.0
+towncrier
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,14 +16,15 @@ attrs==20.3.0             # via -r requirements.in, checkrs, jsonschema, markdow
 backcall==0.2.0           # via ipython
 black==20.8b1             # via papermill
 bleach==3.2.1             # via nbconvert
+bumpver==2021.1109        # via -r requirements.in
 causalgraphicalmodels==0.0.4  # via -r requirements.in
 certifi==2020.11.8        # via requests
 cffi==1.14.4              # via argon2-cffi
 cfgv==3.2.0               # via pre-commit
 chardet==3.0.4            # via requests
 checkrs==0.2.0            # via -r requirements.in
-click==7.1.2              # via -r requirements.in, black, fitter, papermill, pip-tools
-colorama==0.4.4           # via easydev
+click==7.1.2              # via -r requirements.in, black, bumpver, fitter, papermill, pip-tools, towncrier
+colorama==0.4.4           # via bumpver, easydev
 colorlog==4.6.2           # via easydev
 coverage==5.3             # via -r requirements.in
 cycler==0.10.0            # via matplotlib
@@ -45,12 +46,13 @@ graphviz==0.15            # via causalgraphicalmodels
 identify==1.5.10          # via pre-commit
 idna==2.10                # via requests
 importlib-metadata==3.1.0  # via flake8, jsonschema, pluggy, pre-commit, pytest, virtualenv
+incremental==17.5.0       # via towncrier
 iniconfig==1.1.1          # via pytest
 ipykernel==5.3.4          # via notebook
 ipython-genutils==0.2.0   # via nbformat, notebook, traitlets
 ipython==7.19.0           # via ipykernel
 jedi==0.17.2              # via ipython
-jinja2==2.11.2            # via altair, jupyterlab, jupyterlab-server, nbconvert, notebook
+jinja2==2.11.2            # via altair, jupyterlab, jupyterlab-server, nbconvert, notebook, towncrier
 joblib==0.17.0            # via fitter, scikit-learn
 json5==0.9.5              # via jupyterlab-server
 jsonschema==3.2.0         # via altair, jupyterlab-server, nbformat
@@ -61,6 +63,7 @@ jupyterlab-server==1.2.0  # via jupyterlab
 jupyterlab==2.2.9         # via -r requirements.in
 jupytext==1.7.1           # via -r requirements.in
 kiwisolver==1.3.1         # via matplotlib
+lexid==2020.1005          # via bumpver
 lxml==4.6.2               # via -r requirements.in
 markdown-it-py==0.5.6     # via jupytext
 markupsafe==1.1.1         # via jinja2
@@ -83,6 +86,7 @@ pandas==1.1.4             # via altair, causalgraphicalmodels, checkrs, fitter, 
 pandocfilters==1.4.3      # via nbconvert
 papermill==2.2.2          # via -r requirements.in
 parso==0.7.1              # via jedi
+pathlib2==2.3.5           # via bumpver
 pathspec==0.8.1           # via black
 patsy==0.5.1              # via plotnine, statsmodels
 pexpect==4.8.0            # via easydev, ipython
@@ -118,17 +122,18 @@ scikit-learn==0.23.2      # via -r requirements.in, checkrs
 scipy==1.5.4              # via checkrs, fitter, plotnine, pylogit, scikit-learn, seaborn, statsmodels
 seaborn==0.11.0           # via -r requirements.in, checkrs
 send2trash==1.5.0         # via notebook
-six==1.15.0               # via argon2-cffi, bleach, cycler, jsonschema, patsy, pip-tools, python-dateutil, tenacity, virtualenv
+six==1.15.0               # via argon2-cffi, bleach, cycler, jsonschema, pathlib2, patsy, pip-tools, python-dateutil, tenacity, virtualenv
 statsmodels==0.12.1       # via -r requirements.in, checkrs, plotnine, pylogit
 tenacity==6.2.0           # via papermill
 terminado==0.9.1          # via notebook
 testpath==0.4.4           # via nbconvert
 textwrap3==0.9.2          # via ansiwrap
 threadpoolctl==2.1.0      # via scikit-learn
-toml==0.10.2              # via black, jupytext, pre-commit, pytest
+toml==0.10.2              # via black, bumpver, jupytext, pre-commit, pytest, towncrier
 toolz==0.11.1             # via altair
 torch==1.6.0              # via -r requirements.in, checkrs
 tornado==6.1              # via altair-data-server, ipykernel, jupyter-client, jupyterlab, notebook, terminado
+towncrier==19.2.0         # via -r requirements.in
 tqdm==4.54.0              # via -r requirements.in, checkrs, papermill, pylogit
 traitlets==5.0.5          # via ipykernel, ipython, jupyter-client, jupyter-core, nbclient, nbconvert, nbformat, notebook
 typed-ast==1.4.1          # via black

--- a/src/causal2020/219.trivial
+++ b/src/causal2020/219.trivial
@@ -1,0 +1,1 @@
+Switched to Calendar versioning.

--- a/src/causal2020/__init__.py
+++ b/src/causal2020/__init__.py
@@ -3,4 +3,4 @@ Source files for drawing, testing, simulating, and using causal graphs in a
 mode choice example.
 """
 
-__version__ = "0.1.0"
+__version__ = "2021.1000.5"

--- a/src/causal2020/newsfragments/.gitignore
+++ b/src/causal2020/newsfragments/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
Fixes #218 and fixes #217.

This PR switches the repo versioning from [SemVer](https://semver.org/) to [CalVer](https://calver.org/), with a "YYYY.BUILD.UU" version pattern.
I'm happy to talk through the reasoning of why and the benefits of the chosen versioning scheme.
TL;DR is:
- easier ability to cope with writing-only changes (no ambiguity over major/minor/patch)
- retaining of major / minor distinguishing via 1000-place updates of the version build
- unambiguous semantic meaning of version since it's directly a year ("YYYY") and a week ("UU", i.e. sunday-starting-week-numbers).

This PR also:
- sets up [towncrier](https://github.com/twisted/towncrier) for automatic CHANGELOG creation.
This will be useful when we want to know what changed in the article and / or software between releases.
- adds a CONTRIBUTORS.md file.
This will be useful when generating a DOI for the repo itself.
